### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -2,6 +2,9 @@ name: Python Package using Conda
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kastel-security/polyas-core3-universal-verification/security/code-scanning/1](https://github.com/kastel-security/polyas-core3-universal-verification/security/code-scanning/1)

To fix this issue, add the `permissions` block at the root level of the workflow. This will apply the permissions to all jobs in the workflow. Since the workflow appears to only read repository contents and does not push any changes or create pull requests, the permissions can be limited to `contents: read`. This adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
